### PR TITLE
Return correct number of days in a month

### DIFF
--- a/src/helper.ts
+++ b/src/helper.ts
@@ -35,5 +35,5 @@ export const unit = {
 };
 
 export const getDaysInMonth = (year: number, month: number): number => {
-    return new Date(year, month + 1, 0).getDate();
+    return new Date(year, month, 0).getDate();
 };


### PR DESCRIPTION
getDaysInMonth fixes for August and March only showing 1st to 30th options in DayPicker